### PR TITLE
feat(skills): Add test verification to submit and autopilot workflows

### DIFF
--- a/.claude/skills/autopilot/SKILL.md
+++ b/.claude/skills/autopilot/SKILL.md
@@ -66,9 +66,28 @@ For each task:
 
 **Completion signal**: All plan tasks checked off, tests green.
 
-### Phase 5: Self-Review → reference `/rust-guide`
+### Phase 5: Test Verification + Self-Review → reference `/rust-guide`
 
-Invoke `Skill("rust-guide")` to load conventions, then review all changes:
+Invoke `Skill("rust-guide")` to load conventions, then:
+
+#### 5a. Test Coverage Check
+
+1. List all tests in changed crates. For each public function or endpoint, confirm:
+   - **Success scenario** exists (valid input → expected output)
+   - **Error/edge scenario** exists (invalid input, boundary → expected error)
+
+2. Report coverage:
+   ```
+   ## Test Coverage Report
+   ### <crate>::<module>
+   - ✅ success: <description>
+   - ✅ error: <description>
+   - ❌ missing: <what's not tested>
+   ```
+
+3. Write any missing tests before proceeding.
+
+#### 5b. Code Review
 
 1. `git diff main..HEAD` — read every changed file
 2. Verify against checklist:
@@ -78,7 +97,7 @@ Invoke `Skill("rust-guide")` to load conventions, then review all changes:
 | No `.unwrap()` / `.expect()` in prod | CLAUDE.md |
 | `tracing` only, no `println!` | CLAUDE.md |
 | External endpoints return `ApiResponse` | CLAUDE.md |
-| Every public fn has a test | CLAUDE.md |
+| Every public fn has success + error tests | CLAUDE.md |
 | `thiserror::Error` for error types | /rust-guide |
 | Descriptive naming | /rust-guide |
 | Minimal `pub` boundaries | /rust-guide |

--- a/.claude/skills/submit/SKILL.md
+++ b/.claude/skills/submit/SKILL.md
@@ -33,7 +33,34 @@ Post-implementation submission pipeline: quality enforcement, learning notes, co
    - `git log {base_branch}..HEAD` — existing commits on branch
    - Summarize changes to user before proceeding
 
-### Phase 2: Quality Enforcement
+### Phase 2: Test Verification
+
+**Mandatory — never skip. Must complete before quality checks.**
+
+1. **Inventory test scenarios**: List all tests in changed crates. For each public function or endpoint, confirm both success and failure scenarios exist.
+
+   ```
+   ## Test Coverage Report
+   ### <crate>::<module>
+   - ✅ success: <description>
+   - ✅ error: <description>
+   - ❌ missing: <what's not tested>
+   ```
+
+2. **Write missing tests**: If any public function lacks a success or failure scenario, write them now.
+
+   - **Success scenarios**: Valid input → expected output
+   - **Error/edge scenarios**: Invalid input, missing resource, boundary conditions → expected error type or behavior
+
+3. **Run tests and verify**:
+   ```bash
+   cargo test -- --nocapture 2>&1  # see all output
+   ```
+   - All tests must pass
+   - Both success and failure paths must be exercised
+   - If tests fail, fix and re-run (max 3 attempts)
+
+### Phase 3: Quality Enforcement
 
 **Mandatory — never skip.**
 
@@ -50,7 +77,7 @@ cargo test
 - If tests fail, fix and re-run
 - **All three must pass before continuing**
 
-### Phase 3: Learning Notes
+### Phase 4: Learning Notes
 
 **Mandatory — every PR must include a learning document.**
 
@@ -101,7 +128,7 @@ Date: YYYY-MM-DD
 - The "Further study" checklist should be actionable — specific topics, not vague
 - Present the draft to the user for review before committing
 
-### Phase 4: Commit
+### Phase 5: Commit
 
 1. **Stage changes** (including the learning doc)
    - `git add` specific files — avoid `-A`
@@ -114,7 +141,7 @@ Date: YYYY-MM-DD
 
 3. **Create commit** — present draft message to user for approval
 
-### Phase 5: PR Creation
+### Phase 6: PR Creation
 
 1. **Push branch**
    ```bash
@@ -169,7 +196,7 @@ Date: YYYY-MM-DD
 
 4. Report PR URL to user
 
-### Phase 6: Summary
+### Phase 7: Summary
 
 ```
 Submission Complete

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,8 @@ No unstructured text in API responses. Long-running operations return a pollable
 
 - Unit tests: `#[cfg(test)] mod tests` alongside source
 - Integration tests: top-level `tests/` directory
-- Every public function should have at least one test
+- Every public function must have both **success** and **error/edge** test scenarios
+- All tests must pass before PR submission — no exceptions
 
 ## Prohibitions
 


### PR DESCRIPTION
## Issue
Resolves #3
**Problem**: PR 제출 전 성공/실패 테스트 시나리오 검증 단계가 없음.

## Solution
`/submit`과 `/autopilot` 워크플로우에 테스트 검증 단계를 추가.

## Summary
- `/submit`: 새 Phase 2 (Test Verification) — 모든 public function에 success + error 시나리오 확인 후 quality checks 진행
- `/autopilot`: Phase 5에 테스트 커버리지 체크(5a) 추가, 코드 리뷰(5b) 전 실행
- CLAUDE.md: Test Principles에 성공/실패 시나리오 필수 명시

## Test plan
- [ ] `/submit` SKILL.md에 Phase 2 (Test Verification) 존재 확인
- [ ] `/autopilot` SKILL.md Phase 5에 5a (Test Coverage Check) 존재 확인
- [ ] CLAUDE.md Test Principles에 "success and error/edge test scenarios" 문구 확인
- [ ] Phase 번호가 순서대로 정렬되어 있는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)