### PR TITLE
refactor: Go 가이드라인 추가 및 코드 컨벤션 리팩토링

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -8,7 +8,7 @@ Skills provide focused guides for AI agents. Invoke with `/skill-name`.
 
 | Skill | Purpose | Use When |
 |-------|---------|----------|
-| `/go-guide` | Go coding conventions, error handling, type design, concurrency | Writing or reviewing Go code |
+| `/go-guide` | Go coding conventions, error handling, type design, concurrency, production patterns | Writing or reviewing Go code |
 | `/tdd-guide` | TDD workflow (Red → Green → Refactor) | Implementing features or fixing bugs |
 | `/submit` | Quality checks, learning notes, commit, PR creation | Ready to submit changes |
 

--- a/.claude/skills/go-guide/GO_CODING_GUIDELINES.md
+++ b/.claude/skills/go-guide/GO_CODING_GUIDELINES.md
@@ -1,6 +1,6 @@
 # Go Coding Guidelines
 
-Directives for writing idiomatic Go code derived from production codebase conventions.
+Directives for writing idiomatic Go code.
 
 ---
 

--- a/.claude/skills/go-guide/GO_CODING_GUIDELINES.md
+++ b/.claude/skills/go-guide/GO_CODING_GUIDELINES.md
@@ -1,0 +1,95 @@
+# Go Coding Guidelines
+
+Directives for writing idiomatic Go code derived from production codebase conventions.
+
+---
+
+## Interface Design
+
+- **Define interfaces at the consumer, not the provider.** A service that calls an external client should declare its own interface with only the methods it needs. The concrete implementation satisfies it implicitly.
+- **Keep interfaces small.** 1–5 methods per interface. If an interface grows beyond that, split it by responsibility.
+- **Return concrete types from constructors, accept interfaces in functions.** Constructors (`New*`) return `*ConcreteType`. Business logic functions accept interface parameters for testability.
+- **Name interfaces by capability, not implementation.** Use `SyncClient`, `AuthClient`, `ChatClient` — not `GitHubClientInterface`.
+
+## Error Handling
+
+- **Wrap every error with context using `fmt.Errorf("doing X: %w", err)`.** Every call site that propagates an error must add what operation was attempted.
+- **Use a custom error type with a private struct and public factory functions.** The struct implements the `error` interface plus domain-specific methods (e.g., `StatusCode()`, `Code()`). Expose only `Error(code, msg)` and `Errorf(code, format, args...)` as constructors — never the concrete type.
+- **Extract error properties via interface assertion with comma-ok.** Define small extractor interfaces (`StatusCodeError`, `CodeError`) and helper functions that safely type-assert, falling back to a default on mismatch.
+- **Tie business error codes to HTTP status codes in a single `ErrorCode` struct.** This eliminates scattered status-code decisions in handlers — the error itself knows its HTTP representation.
+- **Declare sentinel errors at package level as `var`.** Use `var errNoClient = errdefs.Error(...)` for well-known, reusable error conditions.
+
+## Type System
+
+- **Use named types over raw primitives for domain concepts.** Define `type TaskManageTool string`, `type IssueStatus string`, etc. This prevents accidental interchange of semantically different strings.
+- **Define typed constants with the named type.** `const Jira TaskManageTool = "jira"` — not bare `const Jira = "jira"`.
+- **Provide `FromStr(string) (T, bool)` parsing functions.** Return `(value, ok)` tuple for safe conversion from external input, matching Go's comma-ok convention.
+- **Use semantic type aliases for map keys/values.** `map[LablupEmail]GitHubUserName` is self-documenting and prevents key/value mix-ups that `map[string]string` allows.
+
+## Struct Design
+
+- **Distinguish required vs optional fields with value types vs pointers.** Required fields use value types (`string`, `int`). Optional fields use pointers (`*string`, `*time.Time`) where `nil` means "not set" — distinct from zero value.
+- **Provide pointer helper functions** (`StringP`, `IntP`, `BoolP`) to eliminate `&` boilerplate when constructing struct literals with optional fields.
+- **Group constructor parameters into an `Args` struct when there are 3+ parameters.** Named fields improve readability and allow non-breaking additions.
+- **Place transformation methods on domain structs.** Methods like `Merge(other)`, `ShortPrint()`, `ToIssue()`, `FromIssue()` belong on the data type that owns the fields.
+
+## Composition & Extension
+
+- **Compose, never inherit.** Go has no inheritance. Extend behavior by holding another type as a field and delegating to it.
+- **Use the decorator pattern to layer behavior onto interfaces.** Wrap an existing `echo.Binder` with a `validateBinder` that calls the original binder then runs validation — same interface, added behavior.
+- **Implement polymorphism via interface + multiple concrete structs.** For example, a `UserQuery` interface with `EmailQuery`, `APIKeyQuery`, `GitHubUserNameQuery` structs each implementing `BuildQueryCondition()`. The repository accepts the interface, not a switch on query type.
+
+## Dependency Injection & Construction
+
+- **Use the fluent builder pattern for assembling dependency graphs.** `NewClients().MustWithGHAppClient(args).WithGHClient(args).MustWithJIRAClient(args)` — each method returns `*self` for chaining.
+- **Prefix with `Must*` when failure is fatal (panic).** Use only during program initialization where recovery is impossible. Prefix with `With*` for infallible or error-returning setup.
+- **Apply the builder pattern consistently across layers.** Clients, Repositories, and Services all follow `New*() → MustWith*/With*` for uniform construction.
+- **Inject factory functions as fields for deferred construction.** Store `func(token string) *Client` in a pool struct to create per-user clients on demand, rather than pre-creating all instances.
+
+## Concurrency
+
+- **Use `atomic.Bool` for simple boolean flags** (e.g., "is server closed"). Avoids mutex overhead for single-field state.
+- **Use `sync.RWMutex` when reads vastly outnumber writes.** Protects shared resources (HTTP clients, caches) without blocking concurrent readers.
+- **Start servers in goroutines, handle signals on the main goroutine.** Use `make(chan os.Signal, 1)` with `signal.Notify` and block on receive for graceful shutdown.
+- **Set flags before triggering shutdown.** `closed.Store(true)` before `Shutdown()` — so the `Start()` goroutine can distinguish intentional stop from unexpected error.
+
+## Context & Logging
+
+- **Thread `context.Context` as the first parameter of every public method.** No exceptions. This carries cancellation, deadlines, and request-scoped data.
+- **Accumulate structured log fields in context.** Use a pattern like `ctx = clog.Field(ctx, "issueKey", key)` so downstream calls automatically include upstream context in log output.
+- **Log at decision points, not at every line.** Log when starting an operation, when a significant branch is taken, and when an error occurs — not every intermediate step.
+
+## Package Structure
+
+- **Organize by architectural layer, not by feature.**
+  - `cmd/` — Entry points. Minimal code, just wiring.
+  - `config/` — Configuration loading and validation.
+  - `data/` — Domain models. Zero external dependencies.
+  - `dto/` — Request/response DTOs. API contract boundary.
+  - `errdefs/` — Error types and codes. Shared across layers.
+  - `clients/` — External API integrations. One sub-package per provider.
+  - `services/` — Business logic. Orchestrates clients and repositories.
+  - `repository/` — Data persistence. Database-specific implementations in sub-packages.
+  - `servers/` — HTTP handlers and middleware. Sub-packages per API version and domain.
+  - `utils/` — Shared utilities. Keep minimal.
+- **Dependencies flow inward.** `cmd → servers → services → {clients, repository} → data`. Inner layers never import outer layers.
+- **One sub-package per external provider.** `clients/ghcli`, `clients/jiracli`, `clients/teamscli` — each owns its own types and API-specific logic.
+- **Separate API-specific representations from domain models.** Each client package defines its own `Issue` struct with `FromIssue()`/`ToIssue()` conversion methods. The domain `data.Issue` stays clean.
+
+## Testing
+
+- **Use `t.Parallel()` in tests that don't share mutable state.** Enables concurrent test execution for faster feedback.
+- **One test function per behavior, not per method.** Name tests by what they verify: `Test_ToIssue`, `TestIssue_FromGitHubIssue`.
+- **Use `testify/assert` for readable assertions.** Prefer `assert.Equal(t, expected, actual)` over manual `if` checks.
+- **Small consumer-side interfaces make mocking trivial.** If the interface has 2 methods, the mock has 2 methods. No heavyweight mock frameworks needed.
+
+## Naming
+
+- **Packages:** Short, singular, lowercase. `data`, `config`, `errdefs`. Sub-packages clarify implementation: `ghcli`, `dbrepo`.
+- **Constructors:** `NewType(args)` returns `*Type`.
+- **Builder methods:** `With*()` (safe) or `MustWith*()` (panics).
+- **Conversion methods:** `FromX()` / `ToX()` for bidirectional type mapping.
+- **Parsing functions:** `TypeFromStr(s string) (Type, bool)`.
+- **Private sentinel errors:** `var errSomething = ...` (lowercase, unexported).
+- **Public error codes:** `UserNotFoundCode`, `JiraAPIFailedCode` (exported, descriptive).
+- **Private types with public interfaces:** `type err struct` (unexported) implements `error` (exported). Control construction through factory functions.

--- a/.claude/skills/go-guide/SKILL.md
+++ b/.claude/skills/go-guide/SKILL.md
@@ -7,7 +7,10 @@ user-invocable: true
 # Go Coding Guide
 
 Condensed conventions for all Go code in this project.
-Reference: [Effective Go](https://go.dev/doc/effective_go), [Go Code Review Comments](https://go.dev/wiki/CodeReviewComments).
+
+**References:**
+- [Effective Go](https://go.dev/doc/effective_go), [Go Code Review Comments](https://go.dev/wiki/CodeReviewComments)
+- [GO_CODING_GUIDELINES.md](./GO_CODING_GUIDELINES.md) — production codebase conventions (interface design, DI, composition, package structure). Read this file for detailed patterns beyond the condensed guide below.
 
 ## Error Handling
 

--- a/internal/common/response.go
+++ b/internal/common/response.go
@@ -1,30 +1,39 @@
 package common
 
-// ApiResponse is the standard API response envelope.
+// APIStatus represents the outcome status of an API response.
+type APIStatus string
+
+// API status constants.
+const (
+	StatusOK    APIStatus = "ok"
+	StatusError APIStatus = "error"
+)
+
+// APIResponse is the standard API response envelope.
 // All external API responses use this structure:
 //
 //	{"status": "...", "reason": "...", "next_action_hint": "..."}
-type ApiResponse struct {
-	Status         string `json:"status"`
-	Reason         string `json:"reason"`
-	NextActionHint string `json:"next_action_hint"`
+type APIResponse struct {
+	Status         APIStatus `json:"status"`
+	Reason         string    `json:"reason"`
+	NextActionHint string    `json:"next_action_hint"`
 }
 
-// NewApiResponse creates an ApiResponse with all fields set.
-func NewApiResponse(status, reason, nextActionHint string) ApiResponse {
-	return ApiResponse{
+// NewAPIResponse creates an APIResponse with all fields set.
+func NewAPIResponse(status APIStatus, reason, nextActionHint string) APIResponse {
+	return APIResponse{
 		Status:         status,
 		Reason:         reason,
 		NextActionHint: nextActionHint,
 	}
 }
 
-// OkResponse creates a successful ApiResponse with status "ok".
-func OkResponse(reason, nextActionHint string) ApiResponse {
-	return NewApiResponse("ok", reason, nextActionHint)
+// OKResponse creates a successful APIResponse with status "ok".
+func OKResponse(reason, nextActionHint string) APIResponse {
+	return NewAPIResponse(StatusOK, reason, nextActionHint)
 }
 
-// ErrorResponse creates an error ApiResponse with status "error".
-func ErrorResponse(reason, nextActionHint string) ApiResponse {
-	return NewApiResponse("error", reason, nextActionHint)
+// ErrorResponse creates an error APIResponse with status "error".
+func ErrorResponse(reason, nextActionHint string) APIResponse {
+	return NewAPIResponse(StatusError, reason, nextActionHint)
 }

--- a/internal/common/response_test.go
+++ b/internal/common/response_test.go
@@ -5,11 +5,11 @@ import (
 	"testing"
 )
 
-func TestNewApiResponseSetsAllFields(t *testing.T) {
-	resp := NewApiResponse("healthy", "service is running", "proceed with requests")
+func TestNewAPIResponseSetsAllFields(t *testing.T) {
+	resp := NewAPIResponse("healthy", "service is running", "proceed with requests")
 
 	if resp.Status != "healthy" {
-		t.Errorf("got status %q, want %q", resp.Status, "healthy")
+		t.Errorf("got status %q, want %q", resp.Status, APIStatus("healthy"))
 	}
 	if resp.Reason != "service is running" {
 		t.Errorf("got reason %q, want %q", resp.Reason, "service is running")
@@ -19,24 +19,24 @@ func TestNewApiResponseSetsAllFields(t *testing.T) {
 	}
 }
 
-func TestOkResponseSetsStatusToOk(t *testing.T) {
-	resp := OkResponse("done", "continue")
+func TestOKResponseSetsStatusToOK(t *testing.T) {
+	resp := OKResponse("done", "continue")
 
-	if resp.Status != "ok" {
-		t.Errorf("got status %q, want %q", resp.Status, "ok")
+	if resp.Status != StatusOK {
+		t.Errorf("got status %q, want %q", resp.Status, StatusOK)
 	}
 }
 
 func TestErrorResponseSetsStatusToError(t *testing.T) {
 	resp := ErrorResponse("failed", "retry later")
 
-	if resp.Status != "error" {
-		t.Errorf("got status %q, want %q", resp.Status, "error")
+	if resp.Status != StatusError {
+		t.Errorf("got status %q, want %q", resp.Status, StatusError)
 	}
 }
 
-func TestApiResponseSerializesToJSON(t *testing.T) {
-	resp := NewApiResponse("healthy", "all good", "send requests")
+func TestAPIResponseSerializesToJSON(t *testing.T) {
+	resp := NewAPIResponse(StatusOK, "all good", "send requests")
 
 	data, err := json.Marshal(resp)
 	if err != nil {
@@ -48,8 +48,8 @@ func TestApiResponseSerializesToJSON(t *testing.T) {
 		t.Fatalf("unexpected unmarshal error: %v", err)
 	}
 
-	if m["status"] != "healthy" {
-		t.Errorf("got status %q, want %q", m["status"], "healthy")
+	if m["status"] != "ok" {
+		t.Errorf("got status %q, want %q", m["status"], "ok")
 	}
 	if m["reason"] != "all good" {
 		t.Errorf("got reason %q, want %q", m["reason"], "all good")
@@ -59,16 +59,16 @@ func TestApiResponseSerializesToJSON(t *testing.T) {
 	}
 }
 
-func TestApiResponseDeserializesFromJSON(t *testing.T) {
+func TestAPIResponseDeserializesFromJSON(t *testing.T) {
 	input := `{"status":"ok","reason":"done","next_action_hint":"proceed"}`
 
-	var resp ApiResponse
+	var resp APIResponse
 	if err := json.Unmarshal([]byte(input), &resp); err != nil {
 		t.Fatalf("unexpected unmarshal error: %v", err)
 	}
 
-	if resp.Status != "ok" {
-		t.Errorf("got status %q, want %q", resp.Status, "ok")
+	if resp.Status != StatusOK {
+		t.Errorf("got status %q, want %q", resp.Status, StatusOK)
 	}
 	if resp.Reason != "done" {
 		t.Errorf("got reason %q, want %q", resp.Reason, "done")

--- a/internal/manager/app_test.go
+++ b/internal/manager/app_test.go
@@ -20,7 +20,7 @@ func TestHealthReturns200OK(t *testing.T) {
 		t.Errorf("got status %d, want %d", rec.Code, http.StatusOK)
 	}
 
-	var resp common.ApiResponse
+	var resp common.APIResponse
 	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}

--- a/internal/manager/health.go
+++ b/internal/manager/health.go
@@ -8,7 +8,7 @@ import (
 )
 
 func handleHealth(w http.ResponseWriter, _ *http.Request) {
-	resp := common.OkResponse("healthy", "")
+	resp := common.OKResponse("healthy", "")
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
## Summary
- 프로덕션 코드베이스에서 추출한 Go 코딩 가이드라인(`GO_CODING_GUIDELINES.md`)을 `/go-guide` 스킬에 추가
  - interface design, DI, composition, package structure 등 상세 패턴 포함
- 가이드라인 기준으로 기존 코드를 리팩토링:
  - **Go 약어 네이밍 컨벤션 적용**: `ApiResponse` → `APIResponse`, `OkResponse` → `OKResponse` (Go에서 약어는 전부 대문자)
  - **원시 타입 대신 named type 도입**: `Status` 필드를 raw `string`에서 `APIStatus` 타입으로 변경, `StatusOK`/`StatusError` 상수 정의
- 모든 consumer(health handler, 테스트) 업데이트

## Changed files

| 파일 | 변경 내용 |
|------|----------|
| `.claude/skills/go-guide/GO_CODING_GUIDELINES.md` | 프로덕션 코딩 가이드라인 추가 (신규) |
| `.claude/skills/go-guide/SKILL.md` | 가이드라인 문서 참조 추가 |
| `.claude/skills/README.md` | go-guide 설명 업데이트 |
| `internal/common/response.go` | `APIStatus` 타입 도입, 네이밍 리팩토링 |
| `internal/common/response_test.go` | 새 타입/상수 사용으로 테스트 갱신 |
| `internal/manager/health.go` | `OKResponse` 호출로 변경 |
| `internal/manager/app_test.go` | `APIResponse` 타입 사용으로 변경 |

## Test plan
- [x] `go test ./...` — all pass
- [x] `golangci-lint run ./...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 문서

* Go 코딩 가이드라인 추가 - 인터페이스 설계, 오류 처리, 동시성 등 프로덕션 코드 규칙 포함
* Go 가이드 참조 문서 업데이트

## 개선 사항

* API 응답 구조 타입 안정성 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->