### PR TITLE
chore: tune CodeRabbit review config

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -3,37 +3,45 @@ early_access: false
 enable_free_tier: true
 
 reviews:
-  profile: "assertive"
+  profile: "chill"
   high_level_summary: true
   review_status: true
   collapse_walkthrough: false
   sequence_diagrams: true
   poem: false
+  finishing_touches:
+    unit_tests:
+      enabled: false
   path_filters:
     - "!docs/learn/**"
   path_instructions:
     - path: "internal/**/*.go"
       instructions: |
-        This is a Go project.
-        Enforce these rules strictly:
-        - No panic() in library code
+        This is a Go project. Flag only high-confidence, important issues; skip
+        stylistic nitpicks. Enforce these rules:
+        - No panic() in library code; return error values
         - No fmt.Println — use log/slog for structured logging
-        - All public functions must have success and error test scenarios
-        - External API responses must use the ApiResponse struct
+        - External API responses must use the response envelope in
+          internal/common/dto/response (response.Response / response.Err) with a
+          stable error.code from internal/common/errordef — no ad-hoc JSON
+        Do not flag missing unit tests or test coverage; test scope is decided per-change.
     - path: "internal/common/**"
       instructions: |
-        This is the shared types package (dependency graph leaf).
-        It must NOT depend on any other internal package.
-        Changes to ApiResponse affect all consumers — flag breaking changes.
+        Shared code used across binaries and manager/agent.
+        - Must NOT import manager, agent, server, service, or repository
+          implementation packages. Cross-dependencies within internal/common are allowed.
+        - The response envelope (dto/response) and errordef are shared contracts —
+          flag breaking changes that ripple to consumers.
     - path: "internal/manager/**"
       instructions: |
-        This is the HTTP API server package.
-        main.go should only contain bootstrap logic.
-        New endpoints need a dedicated handler + route registration.
+        Manager application layer. internal/manager owns composition/wiring;
+        request parsing and routes live in servers/ handler packages; business
+        workflow lives in service/ packages. New endpoints need a dedicated
+        handler + route registration. Process bootstrap is in cmd/manager/main.go only.
     - path: "internal/agent/**"
       instructions: |
-        This is the agent package.
-        Same rules as manager — main.go is bootstrap only.
+        Agent library code. Process bootstrap is in cmd/agent/main.go only
+        (internal/agent must not contain entry-point/bootstrap logic).
   auto_review:
     enabled: true
     drafts: false


### PR DESCRIPTION
## Background

CodeRabbit 리뷰가 \"테스트 코드 없음\" nitpick으로 가득 찼고, 일부 `path_instructions`가 실제 코드와 어긋나 있었다 (존재하지 않는 `ApiResponse` 타입, common 내부 의존까지 막는 문구, 패키지 내 `main.go` 가정).

## Changes

- `profile`: `assertive` → `chill`, 그리고 "high-confidence·중요 이슈만, 스타일 nitpick 생략" 지시 추가
- 테스트 누락/커버리지 지적 중단 (테스트 범위는 변경별 판단) + `finishing_touches.unit_tests.enabled: false`
- `path_instructions` 실제 구조에 맞게 정정:
  - 응답 엔벨로프는 `internal/common/dto/response`(`response.Response`/`Err`) + `errordef` (`ApiResponse` 타입 없음)
  - `internal/common`은 manager/agent/server/service/repository import 금지이되 **common 내부 의존은 허용**
  - 프로세스 bootstrap은 `cmd/manager/main.go` / `cmd/agent/main.go` 에만

## Verification
- [ ] PR에서 `@coderabbitai configuration` 으로 effective 설정/문법 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **Chores**
  * 코드 리뷰 설정 및 가이드라인을 업데이트했습니다. 리뷰 프로필을 조정하고, Go 프로젝트 검토 범위와 API 응답 규칙을 재정의하였습니다. 또한 계층별 책임 및 엔드포인트 관련 지침을 보강했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->